### PR TITLE
Add AI pipeline CLI tooling and offline bootstrap support

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,89 +1,85 @@
-WAZUH
-Copyright (C) 2015, Wazuh Inc.
+# WazAI Sentinel Installation Guide
 
-Based on OSSEC
-Copyright (C) 2014 Trend Micro Inc.
+This document describes a streamlined way to deploy WazAI Sentinel with its AI
+augmentation pipeline. The instructions focus on building a modern Python
+environment for the AI agents while still acknowledging the existing
+`install.sh` workflow for the legacy components derived from Wazuh.
 
+## Prerequisites
 
-= Information about OSSEC =
+- Linux or macOS host with Python 3.10+ and a recent `pip`
+- Basic build utilities (`gcc`, `make`) if you intend to compile the legacy
+  C/C++ daemons via `install.sh`
+- Optional: OpenAI and Grok API credentials for live AI enrichment
 
-Visit https://www.wazuh.com
+## Quick Start (AI Manager)
 
+```bash
+git clone https://github.com/<your-org>/WazAI-Sentinel.git
+cd WazAI-Sentinel
 
-= Recommended Installation =
+# 1. Create an isolated Python environment
+python3 -m venv .venv
+source .venv/bin/activate
 
-OSSEC installation is very simple. It can be done in the
-fast way (using the script install.sh with the default values)
-or in the customized way (by hand or by changing the default values
-in the install.sh script). I REALLY recommend EVERYONE to use the
-FAST WAY! Only developers or experienced people should use the
-other methods.
+# 2. Install Python dependencies for the AI agents
+pip install -r framework/requirements.txt
 
-Fast way steps:
+# 3. Bootstrap configuration (add --offline for demo-only environments)
+python -m ai_agents bootstrap --path etc/ai_config.yaml
 
-1- Run the script ./install.sh. It will guide you through the
-   installation process.
+# 4. Inspect configuration, dependencies, and API keys
+python -m ai_agents doctor
 
-2- The script will create everything in /var/ossec and try to
-   create the initialization script in your system (/etc/rc.local
-   or /etc/rc.d/init.d/ossec). If the init script is not created,
-   make sure to follow the instructions from the install.sh to make
-   OSSEC HIDS start during the boot. To start it by hand, just run
-   /var/ossec/bin/wazuh-control start
+# 5. Provide API keys when running with live providers
+export OPENAI_API_KEY="sk-..."
+export GROK_API_KEY="grok-..."
 
-3- If you are running it on multiple clients, make sure to install
-   the server first. Use the manage_agents tool
-   to create the right encryption keys.
+# 6. Simulate the pipeline with a sample alert
+python -m ai_agents run extensions/ai/sample_alert.json --pretty
+```
 
-4- Enjoy.
+Use `python -m ai_agents run ... --offline` to exercise the full agent pipeline
+without contacting external services. Offline mode leverages deterministic
+responses for demonstrations and CI runs.
 
+## Deploying the Full Stack
 
-= Installation and Running (99.99% should read ABOVE) =
+The historical `install.sh` script remains available for provisioning the core
+filebeat/agent infrastructure. Run it from the repository root:
 
+```bash
+sudo ./install.sh
+```
 
-By Hand Installation steps:
+When prompted, choose the appropriate manager or agent role. The installer will
+compile the native components into `/var/ossec` while the AI modules continue to
+run from the Python environment configured above.
 
-1- Create the necessary directories (by default /var/ossec).
-2- Move the necessary files to the ossec directory.
-3- Compile everything.
-4- Move the binaries to the default directory.
-5- Create the necessary users.
-6- Set the right permissions to the files.
+## Configuration Tips
 
+- Customise prompts, providers, and response thresholds in `etc/ai_config.yaml`.
+- Regenerate a configuration file at any time with
+  `python -m ai_agents bootstrap --force`.
+- Validate secrets and optional dependencies in automation pipelines with
+  `python -m ai_agents doctor --json`.
 
-These 5 steps are done in the Makefile (see make server).
+## Upgrades
 
-The Makefile read the options from the LOCATION file. Change
-whatever you need from there.
+1. Pull the latest changes from git: `git pull`
+2. Reinstall Python dependencies if `framework/requirements.txt` changed.
+3. Review configuration drift with `python -m ai_agents doctor`.
+4. Rerun `install.sh` if native modules received updates.
 
-To compile everything by yourself the following dependencies need to be installed:
+## Troubleshooting
 
-- CentOS 6/7
-   $> yum update
-   $> yum install make gcc gcc-c++ policycoreutils-python automake autoconf libtool centos-release-scl devtoolset-7
-   $> scl enable devtoolset-7 bash
+- Missing API keys will appear in the doctor report; export the required
+  variables and rerun.
+- Use `python -m ai_agents run <alert.json> --offline --pretty` to reproduce
+  pipeline behaviour without reaching external APIs.
+- Consult `logs/ossec.log` for daemon-level information after deploying the
+  compiled components.
 
-- CentOS 8
-   $> yum install make gcc gcc-c++ python3 python3-policycoreutils automake autoconf libtool
-   $> rpm -i http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/libstdc++-static-8.3.1-5.1.el8.x86_64.rpm
+For additional guidance review the documentation under `docs/` and
+`extensions/ai/`.
 
-- Debian/Ubuntu
-   $> apt-get install python gcc g++ make libc6-dev curl policycoreutils automake autoconf libtool
-
-The following step is common to all OSes:
-- CMake 3.18 installation
-   $> curl -OL http://packages.wazuh.com/utils/cmake/cmake-3.18.3.tar.gz && tar -zxf cmake-3.18.3.tar.gz
-   $> cd cmake-3.18.3 && ./bootstrap --no-system-curl
-   $> make -j$(nproc) && make install
-   $> cd .. && rm -rf cmake-*
-
-Note: `gcc/g++ 5.5` and `CMake 3.12.4` are the minimun required versions to be installed.
-
-Under wazuh/src folder:
-1- make deps
-2- make TARGET=<agent|server> (Optional: DEBUG=1 TEST=1)
-
-*Before running make server, make sure to have the necessary users created.*
-*The Makefile will not do that.*
-
-#EOF

--- a/README.md
+++ b/README.md
@@ -34,24 +34,34 @@ containment workflows.
 
 ## Getting Started
 
-1. **Install dependencies** – Refer to `framework/requirements.txt` for Python dependencies,
-   including LangChain-ready HTTP clients for OpenAI and Grok.
-2. **Configure API keys** – Export your API keys before starting the manager services:
+1. **Create an isolated Python environment** – `python3 -m venv .venv && source .venv/bin/activate`
+2. **Install dependencies** – `pip install -r framework/requirements.txt`
+3. **Bootstrap configuration** – Generate a starter AI config (add `--offline` for demo mode):
+
+   ```bash
+   python -m ai_agents bootstrap --path etc/ai_config.yaml
+   ```
+
+4. **Run environment checks** – Verify required API keys and packages:
+
+   ```bash
+   python -m ai_agents doctor
+   ```
+
+5. **Provide API credentials** – Export OpenAI and Grok credentials before using live providers:
 
    ```bash
    export OPENAI_API_KEY="sk-..."
    export GROK_API_KEY="grok-..."
    ```
 
-3. **Review AI configuration** – Edit `etc/ai_config.yaml` to customise models, prompts, and
-   action thresholds.
-4. **Run the simulator** – Validate your configuration with the sample alert runner:
+6. **Simulate the pipeline** – Enrich a sample alert (add `--offline` to avoid external calls):
 
    ```bash
-   python3 extensions/ai/simulate_alert.py
+   python -m ai_agents run extensions/ai/sample_alert.json --pretty
    ```
 
-5. **Deploy** – Launch the manager and agents as you would with traditional deployments.
+7. **Deploy** – Launch the manager and agents as you would with traditional deployments.
    New AI insights will appear in stored alerts and in dashboard visualisations.
 
 ## Documentation

--- a/ai_agents/__init__.py
+++ b/ai_agents/__init__.py
@@ -1,9 +1,13 @@
 """WazAI Sentinel AI agent suite."""
 
+from .cli import main as cli_main
 from .config import load_ai_config
+from .pipeline import run_pipeline
 from .supervisor import SupervisorAgent
 
 __all__ = [
+    "cli_main",
     "load_ai_config",
+    "run_pipeline",
     "SupervisorAgent",
 ]

--- a/ai_agents/__main__.py
+++ b/ai_agents/__main__.py
@@ -1,0 +1,9 @@
+"""Module entry point for ``python -m ai_agents``."""
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/ai_agents/agents.py
+++ b/ai_agents/agents.py
@@ -44,7 +44,7 @@ class BaseAIChainAgent:
         cfg = self.context.config.get(self.name, {})
         provider = cfg.get("provider", provider)
         model = cfg.get("model", model)
-        client = build_client(provider, model)
+        client = build_client(provider, model, settings=cfg)
         if client is None:
             raise APIClientError(f"Unsupported AI provider '{provider}' for agent {self.name}")
         self.client = client

--- a/ai_agents/cli.py
+++ b/ai_agents/cli.py
@@ -1,0 +1,220 @@
+"""Command line entry point for WazAI Sentinel AI tooling."""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from .config import DEFAULT_CONFIG_PATH, load_ai_config
+from .diagnostics import (
+    build_offline_config,
+    environment_status,
+    missing_dependencies,
+    required_env_vars,
+    validate_config,
+)
+from .pipeline import run_pipeline
+from .templates import DEFAULT_CONFIG_TEMPLATE
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yaml = None
+
+
+def _dump_config(config: Dict[str, Any]) -> str:
+    if yaml is not None:
+        return yaml.safe_dump(config, sort_keys=False)
+    return json.dumps(config, indent=2)
+
+
+def _load_alert(path: str | None) -> Dict[str, Any]:
+    if not path or path == "-":
+        return json.loads(sys.stdin.read())
+    data = Path(path).read_text(encoding="utf-8")
+    return json.loads(data)
+
+
+def _print_diagnostics(result: Dict[str, Any]) -> None:
+    print("Configuration:")
+    if result["config_path_exists"]:
+        print(f"  path: {result['config_path']}")
+    else:
+        print(f"  path: {result['config_path']} (missing, using defaults)")
+    if result["errors"]:
+        print("  errors:")
+        for item in result["errors"]:
+            print(f"    - {item}")
+    if result["warnings"]:
+        print("  warnings:")
+        for item in result["warnings"]:
+            print(f"    - {item}")
+    print("")
+    print("Environment:")
+    if result["env"]:
+        for entry in result["env"]:
+            status = "present" if entry["present"] else "missing"
+            print(f"  {entry['variable']}: {status}")
+    else:
+        print("  No API keys required for the current configuration.")
+    if result["dependencies"]:
+        print("")
+        print("Missing Python packages:")
+        for package in result["dependencies"]:
+            print(f"  - {package}")
+
+
+def command_bootstrap(args: argparse.Namespace) -> int:
+    destination = Path(args.path or DEFAULT_CONFIG_PATH)
+    if destination.exists() and not args.force:
+        print(f"Configuration already exists at {destination}. Use --force to overwrite.")
+        return 1
+
+    config = copy.deepcopy(DEFAULT_CONFIG_TEMPLATE)
+    if args.offline:
+        config = build_offline_config(config)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(_dump_config(config), encoding="utf-8")
+    print(f"Wrote WazAI Sentinel AI configuration to {destination}")
+    if args.offline:
+        print("Offline mode enabled: generated static responses for all agents.")
+    else:
+        print("Remember to export OPENAI_API_KEY and GROK_API_KEY before running the pipeline.")
+    return 0
+
+
+def command_doctor(args: argparse.Namespace) -> int:
+    config_path = Path(args.config or DEFAULT_CONFIG_PATH)
+    config_data = load_ai_config(config_path)
+    effective_config = config_data or copy.deepcopy(DEFAULT_CONFIG_TEMPLATE)
+    errors, warnings = validate_config(config_data)
+    env_vars = required_env_vars(effective_config)
+    env_status = environment_status(env_vars)
+    missing = missing_dependencies(effective_config)
+
+    result = {
+        "config_path": str(config_path),
+        "config_path_exists": config_path.exists(),
+        "errors": errors,
+        "warnings": warnings,
+        "env": env_status,
+        "dependencies": missing,
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        _print_diagnostics(result)
+
+    return 0 if not errors else 2
+
+
+def command_run(args: argparse.Namespace) -> int:
+    config_path = Path(args.config) if args.config else None
+    config_data = load_ai_config(config_path) if config_path else {}
+    if not config_data:
+        config_data = copy.deepcopy(DEFAULT_CONFIG_TEMPLATE)
+    if args.offline:
+        config_data = build_offline_config(config_data)
+
+    alert = _load_alert(args.alert)
+    enriched = run_pipeline(alert, config=config_data)
+
+    output = json.dumps(enriched, indent=2 if args.pretty else None)
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+    else:
+        print(output)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="wazai",
+        description="Utilities for managing the WazAI Sentinel AI pipeline.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    bootstrap = subparsers.add_parser(
+        "bootstrap",
+        help="Generate a starter ai_config.yaml file.",
+    )
+    bootstrap.add_argument(
+        "--path",
+        "-p",
+        help="Destination path for the generated configuration (default: etc/ai_config.yaml).",
+    )
+    bootstrap.add_argument(
+        "--offline",
+        action="store_true",
+        help="Produce a configuration that uses static responses instead of live API calls.",
+    )
+    bootstrap.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing configuration file.",
+    )
+    bootstrap.set_defaults(func=command_bootstrap)
+
+    doctor = subparsers.add_parser(
+        "doctor",
+        help="Inspect configuration, dependencies, and API keys.",
+    )
+    doctor.add_argument(
+        "--config",
+        "-c",
+        help="Path to the ai_config.yaml file (default: etc/ai_config.yaml).",
+    )
+    doctor.add_argument(
+        "--json",
+        action="store_true",
+        help="Return diagnostics as JSON for automation.",
+    )
+    doctor.set_defaults(func=command_doctor)
+
+    run = subparsers.add_parser(
+        "run",
+        help="Execute the AI pipeline for an alert JSON payload.",
+    )
+    run.add_argument(
+        "alert",
+        help="Path to the alert JSON file. Use '-' to read from stdin.",
+    )
+    run.add_argument(
+        "--config",
+        "-c",
+        help="Path to the ai_config.yaml file (default: etc/ai_config.yaml).",
+    )
+    run.add_argument(
+        "--offline",
+        action="store_true",
+        help="Ignore live providers and use offline static responses.",
+    )
+    run.add_argument(
+        "--output",
+        "-o",
+        help="Write the enriched alert to this file instead of stdout.",
+    )
+    run.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    run.set_defaults(func=command_run)
+
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/ai_agents/clients.py
+++ b/ai_agents/clients.py
@@ -1,8 +1,9 @@
 """API clients used by the WazAI Sentinel AI agents."""
 from __future__ import annotations
 
+import json
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 try:
     import requests
@@ -86,10 +87,38 @@ class GrokClient:
         return data["choices"][0]["message"]["content"].strip()
 
 
-def build_client(provider: str, model: str) -> Optional[object]:
+class StaticResponseClient:
+    """Deterministic client used for offline demonstrations and tests."""
+
+    def __init__(self, model: str, settings: Mapping[str, Any] | None = None) -> None:
+        self.model = model
+        self.settings = dict(settings or {})
+
+    def complete(self, prompt: str, *, temperature: float = 0.1) -> str:  # noqa: ARG002 - parity
+        if "response" in self.settings:
+            payload = self.settings["response"]
+            if isinstance(payload, (dict, list)):
+                return json.dumps(payload)
+            if isinstance(payload, str):
+                return payload.format(prompt=prompt)
+        summary = {
+            "model": self.model,
+            "prompt_tokens": len(prompt),
+        }
+        if self.settings.get("echo_prompt"):
+            summary["prompt"] = prompt
+        return json.dumps(summary)
+
+
+def build_client(
+    provider: str, model: str, *, settings: Mapping[str, Any] | None = None
+) -> Optional[object]:
     """Factory returning the correct API client for *provider*."""
-    if provider.lower() == "openai":
+    provider_key = provider.lower()
+    if provider_key == "openai":
         return OpenAIClient(model)
-    if provider.lower() == "grok":
+    if provider_key == "grok":
         return GrokClient(model)
+    if provider_key in {"mock", "static", "offline"}:
+        return StaticResponseClient(model, settings)
     return None

--- a/ai_agents/diagnostics.py
+++ b/ai_agents/diagnostics.py
@@ -1,0 +1,182 @@
+"""Diagnostics helpers for WazAI Sentinel configuration and runtime checks."""
+from __future__ import annotations
+
+import copy
+import os
+from importlib import util as importlib_util
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+
+DEFAULT_AGENT_ORDER: Tuple[str, ...] = (
+    "investigator",
+    "triage",
+    "enricher",
+    "correlator",
+    "responder",
+)
+
+PROVIDER_ENV_VARS: Dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "grok": "GROK_API_KEY",
+}
+
+PROVIDER_DEPENDENCIES: Dict[str, Tuple[str, ...]] = {
+    "openai": ("requests",),
+    "grok": ("requests",),
+}
+
+OFFLINE_AGENT_RESPONSES: Dict[str, Dict[str, Any]] = {
+    "investigator": {
+        "summary": "Offline analysis placeholder",
+        "findings": ["No live API calls were made."],
+        "risk": "medium",
+    },
+    "triage": {
+        "severity": "medium",
+        "justification": "Offline mode assumes moderate impact for demonstration.",
+    },
+    "enricher": {
+        "intel": ["Add live threat intelligence by disabling offline mode."],
+        "actions": ["Review host hardening", "Collect additional telemetry"],
+        "references": ["https://wazai.example/offline"],
+    },
+    "correlator": {
+        "correlations": ["Historical event correlation not available offline"],
+        "notes": "Connect to production data sources for full correlation.",
+    },
+    "responder": {
+        "actions": [
+            {
+                "type": "notify",
+                "channel": "security_ops",
+                "reason": "Offline demo generated notification",
+            }
+        ],
+        "policy": "Escalate through standard SOC workflow during offline demos.",
+    },
+}
+
+
+def _normalise_agents(config: Mapping[str, Any]) -> Dict[str, Dict[str, Any]]:
+    agents_cfg = config.get("agents")
+    if not isinstance(agents_cfg, Mapping):
+        return {}
+    normalised: Dict[str, Dict[str, Any]] = {}
+    for name, value in agents_cfg.items():
+        if isinstance(name, str) and isinstance(value, Mapping):
+            normalised[name] = dict(value)
+    return normalised
+
+
+def validate_config(config: Mapping[str, Any]) -> Tuple[List[str], List[str]]:
+    """Validate *config* returning a tuple of ``(errors, warnings)``."""
+
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    if not config:
+        warnings.append(
+            "Configuration file not found or empty; defaults will be used when running the pipeline."
+        )
+        return errors, warnings
+
+    agents = _normalise_agents(config)
+    if not agents:
+        errors.append("No agents are defined under the 'agents' section.")
+
+    order = config.get("order")
+    if order is None:
+        warnings.append("Pipeline order not specified; using default agent order.")
+        order_seq: Sequence[str] = DEFAULT_AGENT_ORDER
+    elif isinstance(order, Sequence) and not isinstance(order, (str, bytes)):
+        order_seq = [str(name) for name in order]
+    else:
+        errors.append("The 'order' setting must be a list of agent names.")
+        order_seq = []
+
+    for name in order_seq:
+        if name not in agents:
+            warnings.append(f"Agent '{name}' is referenced in 'order' but not configured.")
+
+    action_threshold = config.get("action_threshold")
+    if action_threshold is not None:
+        valid_levels = {"low", "medium", "high"}
+        if str(action_threshold).lower() not in valid_levels:
+            warnings.append(
+                "Unknown action_threshold value '%s'. Expected one of: low, medium, high." % action_threshold
+            )
+
+    actions = config.get("actions")
+    if actions is not None and not isinstance(actions, Mapping):
+        errors.append("The 'actions' section must be a mapping of action names to settings.")
+
+    return errors, warnings
+
+
+def extract_providers(config: Mapping[str, Any]) -> List[str]:
+    """Return a list of unique provider identifiers referenced by the configuration."""
+
+    providers = []
+    agents = _normalise_agents(config)
+    for agent_cfg in agents.values():
+        provider = agent_cfg.get("provider")
+        if isinstance(provider, str):
+            provider_key = provider.lower()
+            if provider_key not in providers:
+                providers.append(provider_key)
+    return providers
+
+
+def required_env_vars(config: Mapping[str, Any]) -> List[str]:
+    """Return the environment variables required by providers in *config*."""
+
+    providers = extract_providers(config)
+    env_vars = {PROVIDER_ENV_VARS[p] for p in providers if p in PROVIDER_ENV_VARS}
+    return sorted(env_vars)
+
+
+def environment_status(
+    env_vars: Iterable[str], env: Mapping[str, str] | None = None
+) -> List[Dict[str, Any]]:
+    """Return a list describing whether each environment variable is defined."""
+
+    source = env or os.environ
+    status: List[Dict[str, Any]] = []
+    for var in sorted(env_vars):
+        status.append({"variable": var, "present": bool(source.get(var))})
+    return status
+
+
+def missing_dependencies(config: Mapping[str, Any]) -> List[str]:
+    """Return a sorted list of missing optional Python dependencies."""
+
+    missing: set[str] = set()
+    providers = extract_providers(config)
+    for provider in providers:
+        for dependency in PROVIDER_DEPENDENCIES.get(provider, ()):  # pragma: no branch
+            if importlib_util.find_spec(dependency) is None:
+                missing.add(dependency)
+    return sorted(missing)
+
+
+def build_offline_config(config: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a copy of *config* adjusted to use static offline responses."""
+
+    offline = copy.deepcopy(dict(config))
+    agents = _normalise_agents(offline)
+    if not agents:
+        agents = {}
+    for name, default_response in OFFLINE_AGENT_RESPONSES.items():
+        current = agents.get(name, {})
+        updated: Dict[str, Any] = dict(current)
+        updated["provider"] = "mock"
+        if "response" not in updated:
+            updated["response"] = copy.deepcopy(default_response)
+        agents[name] = updated
+    offline["agents"] = agents
+    if "order" not in offline or not isinstance(offline.get("order"), Sequence):
+        offline["order"] = list(DEFAULT_AGENT_ORDER)
+    if "action_threshold" not in offline:
+        offline["action_threshold"] = "medium"
+    return offline
+

--- a/ai_agents/pipeline.py
+++ b/ai_agents/pipeline.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from . import SupervisorAgent, load_ai_config
+from .config import load_ai_config
+from .supervisor import SupervisorAgent
 
 
-def run_pipeline(alert: Dict[str, Any], config_path: str | None = None) -> Dict[str, Any]:
+def run_pipeline(
+    alert: Dict[str, Any],
+    config_path: str | None = None,
+    *,
+    config: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
     """Execute the AI pipeline for *alert* and return an enriched copy."""
-    config = load_ai_config(config_path)
+    config = config if config is not None else load_ai_config(config_path)
     supervisor = SupervisorAgent(config)
     enriched = supervisor.run(alert)
     actions = supervisor.decide_actions(enriched)

--- a/ai_agents/templates.py
+++ b/ai_agents/templates.py
@@ -1,0 +1,62 @@
+"""Reusable configuration templates for WazAI Sentinel."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .diagnostics import DEFAULT_AGENT_ORDER
+
+
+DEFAULT_CONFIG_TEMPLATE: Dict[str, Any] = {
+    "log_level": "INFO",
+    "action_threshold": "medium",
+    "order": list(DEFAULT_AGENT_ORDER),
+    "agents": {
+        "investigator": {
+            "provider": "openai",
+            "model": "gpt-4o",
+            "prompt": (
+                "You are WazAI Sentinel's Investigator. Evaluate the alert data below and return "
+                "JSON with keys summary, findings, risk. Use concise bullet lists. Data: {data}"
+            ),
+        },
+        "triage": {
+            "provider": "grok",
+            "model": "grok-beta",
+            "prompt": (
+                "Determine severity (high/medium/low) and justification as JSON with keys "
+                "severity and justification. Data: {data}"
+            ),
+        },
+        "enricher": {
+            "provider": "openai",
+            "model": "gpt-4o",
+            "prompt": (
+                "Provide contextual threat intelligence, recommended response steps, and references. "
+                "Return JSON with keys intel, actions, references. Data: {data}"
+            ),
+        },
+        "correlator": {
+            "provider": "openai",
+            "model": "gpt-4o",
+            "prompt": (
+                "Correlate the alert with historical events, highlighting related incident IDs or tactics. "
+                "Return JSON keys correlations and notes. Data: {data}"
+            ),
+        },
+        "responder": {
+            "provider": "openai",
+            "model": "gpt-4o",
+            "prompt": (
+                "Provide an incident response action plan that aligns with organisational playbooks. "
+                "Return JSON with keys actions (list of objects with type, reason, and parameters) "
+                "and policy (string). Data: {data}"
+            ),
+        },
+    },
+    "actions": {
+        "notify": {"channel": "security_ops"},
+        "create_ticket": {"system": "jira"},
+        "isolate_endpoint": {"enabled": False},
+    },
+}
+

--- a/docs/ai_agents.md
+++ b/docs/ai_agents.md
@@ -71,6 +71,16 @@ export OPENAI_API_KEY="sk-..."
 export GROK_API_KEY="grok-..."
 ```
 
+### Tooling
+
+- `python -m ai_agents bootstrap` – Generate a starter `ai_config.yaml`
+  (add `--offline` for deterministic mock responses).
+- `python -m ai_agents doctor` – Validate configuration structure, API keys,
+  and optional Python dependencies.
+- `python -m ai_agents run <alert.json>` – Execute the pipeline for a given
+  alert payload. Combine with `--offline` to exercise the workflow without
+  external API calls.
+
 ## Error Handling
 
 - Missing API keys raise `APIClientError` and are recorded in the enriched alert payload under

--- a/extensions/ai/README.md
+++ b/extensions/ai/README.md
@@ -11,10 +11,16 @@ AI pipeline with external systems.
 
 ## Usage
 
-Export valid API keys before running the simulator:
+Export valid API keys before running the simulator (or use `--offline` to avoid remote calls):
 
 ```bash
 export OPENAI_API_KEY=your_openai_key
 export GROK_API_KEY=your_grok_key
-python3 extensions/ai/simulate_alert.py
+python -m ai_agents run extensions/ai/sample_alert.json --pretty
+```
+
+You can still run the original helper script directly:
+
+```bash
+python3 extensions/ai/simulate_alert.py --offline
 ```

--- a/extensions/ai/simulate_alert.py
+++ b/extensions/ai/simulate_alert.py
@@ -1,19 +1,72 @@
 """Simulate running the WazAI Sentinel AI pipeline on a sample alert."""
 from __future__ import annotations
 
+import argparse
+import copy
 import json
 from pathlib import Path
 
+from ai_agents.config import load_ai_config
+from ai_agents.diagnostics import build_offline_config
 from ai_agents.pipeline import run_pipeline
+from ai_agents.templates import DEFAULT_CONFIG_TEMPLATE
 
 SAMPLE_PATH = Path(__file__).with_name("sample_alert.json")
 
 
-def main() -> None:
-    alert = json.loads(SAMPLE_PATH.read_text(encoding="utf-8"))
-    enriched = run_pipeline(alert)
-    print(json.dumps(enriched, indent=2))
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        "-i",
+        default=str(SAMPLE_PATH),
+        help="Path to an alert JSON payload (default: sample_alert.json).",
+    )
+    parser.add_argument(
+        "--config",
+        "-c",
+        help="Path to ai_config.yaml (defaults to etc/ai_config.yaml).",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Use static responses instead of calling external providers.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Write enriched alert JSON to this path instead of stdout.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    return parser
 
 
-if __name__ == "__main__":
-    main()
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    alert_path = Path(args.input)
+    alert = json.loads(alert_path.read_text(encoding="utf-8"))
+
+    config = load_ai_config(args.config)
+    if not config:
+        config = copy.deepcopy(DEFAULT_CONFIG_TEMPLATE)
+    if args.offline:
+        config = build_offline_config(config)
+
+    enriched = run_pipeline(alert, config=config)
+    output = json.dumps(enriched, indent=2 if args.pretty else None)
+
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+    else:
+        print(output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience script
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,59 @@
+"""Tests for the ai_agents CLI utilities."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from ai_agents import cli  # noqa: E402
+try:  # pragma: no cover - optional dependency
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover
+    yaml = None
+
+
+def test_bootstrap_offline_generates_mock_config(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    destination = tmp_path / "ai.yaml"
+    exit_code = cli.main(["bootstrap", "--path", str(destination), "--offline"])
+    assert exit_code == 0
+    captured = capsys.readouterr().out
+    assert "Offline mode" in captured
+    raw = destination.read_text(encoding="utf-8")
+    if yaml is not None:
+        config = yaml.safe_load(raw)
+    else:
+        config = json.loads(raw)
+    assert config["agents"]["triage"]["provider"] == "mock"
+
+
+def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    config_path = tmp_path / "ai.yaml"
+    cli.main(["bootstrap", "--path", str(config_path), "--offline"])
+    capsys.readouterr()
+    exit_code = cli.main(["doctor", "--config", str(config_path), "--json"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert payload["config_path"] == str(config_path)
+    assert payload["errors"] == []
+    if payload["warnings"]:
+        assert payload["warnings"] == [
+            "Configuration file not found or empty; defaults will be used when running the pipeline."
+        ]
+
+
+def test_run_offline_outputs_enriched_alert(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    alert_path = tmp_path / "alert.json"
+    alert_path.write_text(json.dumps({"id": "demo", "rule": {"description": "test"}}), encoding="utf-8")
+    exit_code = cli.main(["run", str(alert_path), "--offline", "--pretty"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    enriched = json.loads(output)
+    assert "ai" in enriched
+    assert enriched["ai_actions"]


### PR DESCRIPTION
## Summary
- add a new `ai_agents` CLI with bootstrap, doctor, and run commands plus deterministic offline mode
- introduce diagnostics utilities, reusable configuration templates, and tests covering the CLI workflow
- refresh installation docs and simulation tooling to guide the improved setup experience

## Testing
- pytest tests/test_ai_actions.py tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d826ab29548328ba785e8f90636c10