### PR TITLE
Add interactive AI model configuration flow

### DIFF
--- a/ai_agents/cli.py
+++ b/ai_agents/cli.py
@@ -6,7 +6,7 @@ import copy
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
 from .config import DEFAULT_CONFIG_PATH, load_ai_config
 from .diagnostics import (
@@ -23,6 +23,47 @@ try:
     import yaml
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     yaml = None
+
+
+MODEL_CATALOG: Dict[str, Dict[str, Sequence[Tuple[str, str]]]] = {
+    "openai": {
+        "label": "OpenAI",
+        "models": (
+            ("gpt-4.1", "GPT-4.1 (flagship reasoning)"),
+            ("gpt-4.1-mini", "GPT-4.1 Mini (cost optimised)"),
+            ("o3-mini", "o3 Mini (structured reasoning)"),
+        ),
+    },
+    "anthropic": {
+        "label": "Anthropic Claude",
+        "models": (
+            ("claude-3.5-sonnet", "Claude 3.5 Sonnet (balanced)"),
+            ("claude-3.5-haiku", "Claude 3.5 Haiku (fast)"),
+        ),
+    },
+    "grok": {
+        "label": "Grok",
+        "models": (
+            ("grok-2", "Grok 2 (latest general model)"),
+            ("grok-beta", "Grok Beta (legacy compatibility)"),
+        ),
+    },
+    "google": {
+        "label": "Google Gemini",
+        "models": (
+            ("gemini-1.5-pro", "Gemini 1.5 Pro (multimodal capable)"),
+            ("gemini-1.5-flash", "Gemini 1.5 Flash (low latency)"),
+        ),
+    },
+}
+
+AGENT_TASK_DESCRIPTIONS: Dict[str, str] = {
+    "investigator": "Investigate alerts and summarise key findings",
+    "triage": "Assign severity and justification",
+    "enricher": "Add contextual threat intelligence",
+    "correlator": "Cross-reference with historical incidents",
+    "responder": "Propose incident response actions",
+}
 
 
 def _dump_config(config: Dict[str, Any]) -> str:
@@ -83,7 +124,10 @@ def command_bootstrap(args: argparse.Namespace) -> int:
     if args.offline:
         print("Offline mode enabled: generated static responses for all agents.")
     else:
-        print("Remember to export OPENAI_API_KEY and GROK_API_KEY before running the pipeline.")
+        print(
+            "Remember to export OPENAI_API_KEY, GROK_API_KEY, ANTHROPIC_API_KEY, or "
+            "GOOGLE_API_KEY as required before running the pipeline."
+        )
     return 0
 
 
@@ -111,6 +155,128 @@ def command_doctor(args: argparse.Namespace) -> int:
         _print_diagnostics(result)
 
     return 0 if not errors else 2
+
+
+def _prompt_choice(
+    title: str,
+    options: Sequence[Tuple[str, str]],
+    default: str | None = None,
+    allow_custom: bool = False,
+) -> str:
+    """Prompt the user to select one of the provided *options*."""
+
+    enumerated: List[Tuple[int, str, str]] = []
+    for index, (value, description) in enumerate(options, start=1):
+        enumerated.append((index, value, description))
+
+    if allow_custom:
+        enumerated.append((len(enumerated) + 1, "__custom__", "Custom value"))
+
+    default_label = f" [{default}]" if default else ""
+    while True:
+        print(title)
+        for idx, value, description in enumerated:
+            marker = "*" if default and value == default else " "
+            print(f"  {idx}. {description} ({value}){marker}")
+        choice = input(f"Enter selection{default_label}: ").strip()
+        if not choice and default:
+            return default
+        if choice.isdigit():
+            idx = int(choice)
+            for number, value, _ in enumerated:
+                if number == idx:
+                    if value == "__custom__":
+                        custom = input("Enter custom value: ").strip()
+                        if custom:
+                            return custom
+                        break
+                    return value
+        else:
+            for _, value, _ in enumerated:
+                if choice.lower() == value.lower():
+                    return value
+        print("Invalid selection. Please choose one of the listed options.")
+
+
+def _prompt_yes_no(prompt: str, default: bool = False) -> bool:
+    yes_values = {"y", "yes"}
+    no_values = {"n", "no"}
+    default_label = "Y/n" if default else "y/N"
+    while True:
+        response = input(f"{prompt} ({default_label}): ").strip().lower()
+        if not response:
+            return default
+        if response in yes_values:
+            return True
+        if response in no_values:
+            return False
+        print("Please respond with 'y' or 'n'.")
+
+
+def command_configure(args: argparse.Namespace) -> int:
+    config_path = Path(args.config or DEFAULT_CONFIG_PATH)
+    existing = load_ai_config(config_path)
+    config = existing or copy.deepcopy(DEFAULT_CONFIG_TEMPLATE)
+    if "agents" not in config:
+        config["agents"] = {}
+
+    print("\n=== WazAI Sentinel AI configuration ===")
+    print(
+        "Select the AI provider and model for each agent task. "
+        "Press Enter to keep the current value.\n"
+    )
+
+    agents = config.get("agents", {})
+    provider_options = [
+        (provider, data["label"])
+        for provider, data in MODEL_CATALOG.items()
+    ]
+
+    for agent_name, agent_config in agents.items():
+        task_description = AGENT_TASK_DESCRIPTIONS.get(agent_name, agent_name)
+        print(f"--- {agent_name.title()} ({task_description}) ---")
+        current_provider = str(agent_config.get("provider", "openai"))
+        provider_choices = list(provider_options)
+        if current_provider not in MODEL_CATALOG:
+            provider_choices.append((current_provider, f"Current provider ({current_provider})"))
+        provider = _prompt_choice(
+            "Select AI provider:",
+            provider_choices,
+            default=current_provider,
+            allow_custom=True,
+        )
+        agent_config["provider"] = provider
+
+        model_list = MODEL_CATALOG.get(provider, {}).get("models", ())
+        current_model = str(agent_config.get("model", ""))
+        model_choices: List[Tuple[str, str]] = list(model_list)
+        known_models = {value for value, _ in model_list}
+        if current_model and current_model not in known_models:
+            model_choices.append((current_model, f"Current model ({current_model})"))
+        if not model_choices:
+            model_choices.append((current_model or provider, f"Default model for {provider}"))
+        model = _prompt_choice(
+            "Select model:",
+            model_choices,
+            default=current_model or model_choices[0][0],
+            allow_custom=True,
+        )
+        agent_config["model"] = model
+
+        if _prompt_yes_no("Would you like to edit the prompt?", default=False):
+            print("Enter the new prompt text. Use {data} as a placeholder for alert JSON.")
+            new_prompt = input("Prompt: ").strip()
+            if new_prompt:
+                agent_config["prompt"] = new_prompt
+
+        print("")
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(_dump_config(config), encoding="utf-8")
+
+    print(f"Saved updated configuration to {config_path}")
+    print("Run 'wazai doctor' to verify environment variables and dependencies.\n")
+    return 0
 
 
 def command_run(args: argparse.Namespace) -> int:
@@ -205,6 +371,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Pretty-print JSON output.",
     )
     run.set_defaults(func=command_run)
+
+    configure = subparsers.add_parser(
+        "configure",
+        help="Interactively choose AI providers, models, and prompts for each agent.",
+    )
+    configure.add_argument(
+        "--config",
+        "-c",
+        help="Path to the ai_config.yaml file (default: etc/ai_config.yaml).",
+    )
+    configure.set_defaults(func=command_configure)
 
     return parser
 

--- a/ai_agents/diagnostics.py
+++ b/ai_agents/diagnostics.py
@@ -18,11 +18,15 @@ DEFAULT_AGENT_ORDER: Tuple[str, ...] = (
 PROVIDER_ENV_VARS: Dict[str, str] = {
     "openai": "OPENAI_API_KEY",
     "grok": "GROK_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GOOGLE_API_KEY",
 }
 
 PROVIDER_DEPENDENCIES: Dict[str, Tuple[str, ...]] = {
     "openai": ("requests",),
     "grok": ("requests",),
+    "anthropic": ("anthropic",),
+    "google": ("google-generativeai",),
 }
 
 OFFLINE_AGENT_RESPONSES: Dict[str, Dict[str, Any]] = {

--- a/ai_agents/templates.py
+++ b/ai_agents/templates.py
@@ -13,31 +13,31 @@ DEFAULT_CONFIG_TEMPLATE: Dict[str, Any] = {
     "agents": {
         "investigator": {
             "provider": "openai",
-            "model": "gpt-4o",
+            "model": "gpt-4.1",
             "prompt": (
                 "You are WazAI Sentinel's Investigator. Evaluate the alert data below and return "
                 "JSON with keys summary, findings, risk. Use concise bullet lists. Data: {data}"
             ),
         },
         "triage": {
-            "provider": "grok",
-            "model": "grok-beta",
+            "provider": "anthropic",
+            "model": "claude-3.5-sonnet",
             "prompt": (
                 "Determine severity (high/medium/low) and justification as JSON with keys "
                 "severity and justification. Data: {data}"
             ),
         },
         "enricher": {
-            "provider": "openai",
-            "model": "gpt-4o",
+            "provider": "google",
+            "model": "gemini-1.5-pro",
             "prompt": (
                 "Provide contextual threat intelligence, recommended response steps, and references. "
                 "Return JSON with keys intel, actions, references. Data: {data}"
             ),
         },
         "correlator": {
-            "provider": "openai",
-            "model": "gpt-4o",
+            "provider": "grok",
+            "model": "grok-2",
             "prompt": (
                 "Correlate the alert with historical events, highlighting related incident IDs or tactics. "
                 "Return JSON keys correlations and notes. Data: {data}"
@@ -45,7 +45,7 @@ DEFAULT_CONFIG_TEMPLATE: Dict[str, Any] = {
         },
         "responder": {
             "provider": "openai",
-            "model": "gpt-4o",
+            "model": "gpt-4.1-mini",
             "prompt": (
                 "Provide an incident response action plan that aligns with organisational playbooks. "
                 "Return JSON with keys actions (list of objects with type, reason, and parameters) "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,3 +57,47 @@ def test_run_offline_outputs_enriched_alert(tmp_path: Path, capsys: pytest.Captu
     enriched = json.loads(output)
     assert "ai" in enriched
     assert enriched["ai_actions"]
+
+
+def test_configure_interactive_updates_models_and_prompts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_path = tmp_path / "ai.yaml"
+    responses = iter(
+        [
+            "1",  # investigator provider -> OpenAI
+            "2",  # investigator model -> gpt-4.1-mini
+            "n",  # investigator prompt unchanged
+            "2",  # triage provider -> Anthropic
+            "1",  # triage model -> claude-3.5-sonnet
+            "y",  # triage prompt edit
+            "Review severity {data}",
+            "4",  # enricher provider -> Google Gemini
+            "1",  # enricher model -> gemini-1.5-pro
+            "n",  # enricher prompt unchanged
+            "3",  # correlator provider -> Grok
+            "1",  # correlator model -> grok-2
+            "n",  # correlator prompt unchanged
+            "1",  # responder provider -> OpenAI
+            "1",  # responder model -> gpt-4.1
+            "n",  # responder prompt unchanged
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+
+    exit_code = cli.main(["configure", "--config", str(config_path)])
+    assert exit_code == 0
+    capsys.readouterr()  # drain output
+
+    raw = config_path.read_text(encoding="utf-8")
+    if yaml is not None:
+        config = yaml.safe_load(raw)
+    else:
+        config = json.loads(raw)
+
+    assert config["agents"]["investigator"]["model"] == "gpt-4.1-mini"
+    assert config["agents"]["triage"]["provider"] == "anthropic"
+    assert config["agents"]["triage"]["prompt"] == "Review severity {data}"
+    assert config["agents"]["enricher"]["model"] == "gemini-1.5-pro"


### PR DESCRIPTION
## Summary
- add a `wazai configure` command that lets operators choose providers, models, and prompts for each agent task
- refresh the default AI templates to use the latest OpenAI, Anthropic, Grok, and Google Gemini models
- extend diagnostics with new provider environment variables and optional dependencies

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d82aad2f908328876671057e846513